### PR TITLE
Add support for `Ed25519ph` with a context

### DIFF
--- a/ed25519.go
+++ b/ed25519.go
@@ -333,13 +333,8 @@ const (
 )
 
 func writeDom2(w io.Writer, f dom2Flag, c []byte) {
-	var cLenMax int
-	if f == fCtx {
-		cLenMax = ContextMaxSize
-	}
-
 	cLen := len(c)
-	if cLen > cLenMax {
+	if cLen > ContextMaxSize {
 		panic("ed25519: bad context length: " + strconv.Itoa(cLen))
 	}
 

--- a/ed25519ctx.go
+++ b/ed25519ctx.go
@@ -39,9 +39,25 @@ func SignContext(privateKey PrivateKey, ctx, message []byte) []byte {
 	return sign(privateKey, message, fCtx, ctx)
 }
 
-// VerifyContext reports whether sig is a valid Ed25519ctx signature  of
+// VerifyContext reports whether sig is a valid Ed25519ctx signature of
 // ctx and mesage by publicKey.  It will panic if len(publicKey) is not
 // PublicKeySize or if len(ctx) is greater than ContextMaxSize.
 func VerifyContext(publicKey PublicKey, ctx, message, sig []byte) bool {
 	return verify(publicKey, message, sig, fCtx, ctx)
+}
+
+// SignHashedContext signs the given pre-hashed message with priv,
+// including the domain-separation context ctx, using Ed25519ph.  It
+// will panic if len(privateKey) is not PrivateKeySize or if len(ctx)
+// is greater than ContextMaxSize.
+func SignHashedContext(privateKey PrivateKey, ctx, hash []byte) []byte {
+	return sign(privateKey, hash, fPh, ctx)
+}
+
+// VerifyHashedContext reports whether sig is a valid Ed25519ph
+// signature of ctx and the pre-hashed mesage by publicKey.  It will
+// panic if len(publicKey) is not PublicKeySize or if len(ctx) is
+// greater than ContextMaxSize.
+func VerifyHashedContext(publicKey PublicKey, ctx, hash, sig []byte) bool {
+	return verify(publicKey, hash, sig, fPh, ctx)
 }


### PR DESCRIPTION
The upstream PR half-asses support for Ed25519ph, by not supporting a
user specified context.  This adds `SignContextHashed` and
`VerifyContextHashed` that exposes this functionality.

Note that this assumes the user is capable of creating the appropriate
pre-hashed input on their own.