### PR TITLE
Add support for batch verifying with Ed25519ctx/Ed25519ph

### DIFF
--- a/batch_verify_test.go
+++ b/batch_verify_test.go
@@ -115,7 +115,8 @@ func testBatchInstance(t *testing.T, tst batchTest, r io.Reader, batchSize int) 
 	}
 
 	// verify the batch
-	ok, valid, err := VerifyBatch(r, pks[:], messages[:], sigs[:])
+	var opts Options
+	ok, valid, err := VerifyBatch(r, pks[:], messages[:], sigs[:], &opts)
 	if err != nil {
 		t.Fatalf("failed to verify batch: %v", err)
 	}
@@ -167,12 +168,13 @@ func TestVerifyBatch(t *testing.T) {
 }
 
 func BenchmarkVerifyBatch64(b *testing.B) {
+	var opts Options
 	pks, sigs, messages := testBatchInit(b, rand.Reader, batchCount)
 	testBatchSaveY = false
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		ok, _, _ := VerifyBatch(nil, pks[:], messages[:], sigs[:])
+		ok, _, _ := VerifyBatch(nil, pks[:], messages[:], sigs[:], &opts)
 		if !ok {
 			b.Fatalf("unexpected batch verification failure!")
 		}

--- a/ed25519.go
+++ b/ed25519.go
@@ -94,7 +94,7 @@ func (opt *Options) HashFunc() crypto.Hash {
 	return opt.Hash
 }
 
-func (opt *Options) unwrap(message []byte) (dom2Flag, []byte, error) {
+func (opt *Options) unwrap() (dom2Flag, []byte, error) {
 	var (
 		context []byte
 		f       dom2Flag = fPure
@@ -161,7 +161,7 @@ func (priv PrivateKey) Sign(rand io.Reader, message []byte, opts crypto.SignerOp
 		f       dom2Flag = fPure
 	)
 	if o, ok := opts.(*Options); ok {
-		f, context, err = o.unwrap(message)
+		f, context, err = o.unwrap()
 		if err != nil {
 			return nil, err
 		}
@@ -305,7 +305,7 @@ func verify(publicKey PublicKey, message, sig []byte, f dom2Flag, c []byte) bool
 // not sha512.Size (if pre-hashed), or len(opts.Context) is greater than
 // ContextMaxSize.
 func VerifyWithOptions(publicKey PublicKey, message, sig []byte, opts *Options) bool {
-	f, context, err := opts.unwrap(message)
+	f, context, err := opts.unwrap()
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Since this API is advanced VerifyBatch just unconditionally takes
options now.  Additionally this adds public key length verification to
be consistent with how Verify works (though it returns an error instead
of panicing since it can).

Fixes #7