### PR TITLE
Address issues found by third party external review.

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,25 @@ The following issues currently limit performance:
  * (`amd64`) This could use a bigger table, AVX2, etc for even more
    performance.
 
+While sanitizing sensitive values from memory is regarded as good practice,
+Go as currently implemented and specified makes this impossible to do reliably
+for several reasons:
+
+ * The runtime can/will make copies of stack-allocated objects if the stack
+   needs to be grown.
+
+ * There is no `memset_s`/`explicit_bzero` equivalent provided by the runtime
+   library (though Go up to and including 1.13.1 will not optimize out the
+   existing sanitization code).
+
+ * The runtime library's SHA-512 implementation's `Reset()` method does not
+   actually clear the buffer, and calculating the digest via `Sum()` creates
+   a copy of the buffer.
+
+This implementation makes some attempts at sanitization, however this process
+is fragile, and does not currently work in certain locations due to one or
+more of the stated reasons.
+
 #### TODO
 
  * Tons of review.

--- a/README.md
+++ b/README.md
@@ -91,7 +91,6 @@ more of the stated reasons.
 
 #### TODO
 
- * Tons of review.
  * Wait for the compiler to inline functions more intelligently.
  * Wait for the compiler to provide `math/bits` SSA special cases on
    more architectures.

--- a/batch_verify.go
+++ b/batch_verify.go
@@ -110,6 +110,8 @@ func heapUpdatedRoot(heap *batchHeap, limbSize int) {
 	childl := 1
 	childr := 2
 	for childr < heap.size {
+		// Note: The termination check is nominally incorrect, in that
+		// it will fail iff the number of nodes is even (only a left-child).
 		if modm.LessThanVartime(&scalars[pheap[childl]], &scalars[pheap[childr]], limbSize) {
 			node = childr
 		} else {
@@ -131,7 +133,7 @@ func heapUpdatedRoot(heap *batchHeap, limbSize int) {
 	}
 }
 
-// build the heap with count elements, count must be >= 3
+// build the heap with count elements, count must be >= 3 and MUST be odd.
 func heapBuild(heap *batchHeap, count int) {
 	// heap_build(batch_heap *heap, size_t count)
 	heap.heap[0] = 0
@@ -209,7 +211,7 @@ func multiScalarmultVartimeFinal(r, point *ge25519.Ge25519, scalar *modm.Bignum2
 	}
 }
 
-// count must be >= 5
+// count must be >= 5 and MUST be odd.
 func multiScalarmultVartime(r *ge25519.Ge25519, heap *batchHeap, count int) {
 	// ge25519_multi_scalarmult_vartime(ge25519 *r, batch_heap *heap, size_t count)
 

--- a/ed25519.go
+++ b/ed25519.go
@@ -327,7 +327,9 @@ func NewKeyFromSeed(seed []byte) PrivateKey {
 		panic("ed25519: bad seed length: " + strconv.Itoa(l))
 	}
 
-	// `sha512.Sum512` does not call d.Reset().
+	// `sha512.Sum512` does not call d.Reset(), but it's somewhat of a
+	// moot point because the runtime library's SHA-512 implementation's
+	// `Reset()` method doesn't actually clear the buffer currently.
 	var digest [64]byte
 	h := sha512.New()
 	_, _ = h.Write(seed)

--- a/internal/ge25519/ge25519.go
+++ b/internal/ge25519/ge25519.go
@@ -401,7 +401,7 @@ func DoubleScalarmultVartime(r, p1 *Ge25519, s1, s2 *modm.Bignum256) {
 
 	abs := func(n int8) int {
 		if n < 0 {
-			return int(-n)
+			return -int(n)
 		}
 		return int(n)
 	}


### PR DESCRIPTION
None of the issues found (apart from the fragility of sanitization) will trigger correctness issues in practice due to the bugs being triggered by inputs that can never happen.