### PR TITLE
internal: Fix the build tags for non-AMD64 platforms

### DIFF
--- a/internal/curve25519/curve25519_donna_32bit.go
+++ b/internal/curve25519/curve25519_donna_32bit.go
@@ -26,10 +26,7 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-// +build !amd64
-// +build !go1.13,arm64
-// +build !go1.13,ppc64le
-// +build !go1.13,ppc64
+// +build 386 arm !go1.13,arm64 !go1.13,ppc64le !go1.13,ppc64 mips mipsle mips64le mips64 s390x
 
 package curve25519
 

--- a/internal/ge25519/tables_32bit.go
+++ b/internal/ge25519/tables_32bit.go
@@ -26,10 +26,7 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-// +build !amd64
-// +build !go1.13,arm64
-// +build !go1.13,ppc64le
-// +build !go1.13,ppc64
+// +build 386 arm !go1.13,arm64 !go1.13,ppc64le !go1.13,ppc64 mips mipsle mips64le mips64 s390x
 
 package ge25519
 

--- a/internal/modm/modm_32bit.go
+++ b/internal/modm/modm_32bit.go
@@ -26,10 +26,7 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-// +build !amd64
-// +build !go1.13,arm64
-// +build !go1.13,ppc64le
-// +build !go1.13,ppc64
+// +build 386 arm !go1.13,arm64 !go1.13,ppc64le !go1.13,ppc64 mips mipsle mips64le mips64 s390x
 
 package modm
 


### PR DESCRIPTION
Doing the build tags this way isn't great, because there's quite a few more architectures that the compiler technically supports, but when people that actually use such things run into issues, it is trivial to add them on a case-by-case basis.

Fixes #16